### PR TITLE
fixed score updation in index.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -99,6 +99,7 @@ io.on("connection", (socket) => {
 
   socket.on("winner", async ({ winnerSocketId, roomId }) => {
     try {
+      if(socket.id!=winnerSocketId){return ;}
       let room = await Room.findById(roomId);
       let player = room.players.find(
         (playerr) => playerr.socketID == winnerSocketId


### PR DESCRIPTION
Earlier "winner" was being emitted by both the users, and the score was being updated twice rather than once, which can also be seen at the end of the video, so we should ignore the event emitted by the loser